### PR TITLE
Add PaaS-specific dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM mdawar/rq-exporter:latest
+
+USER root
+
+RUN apt update && apt install jq -y
+
+COPY docker-entrypoint.sh docker-entrypoint.sh 
+RUN chmod +x docker-entrypoint.sh
+
+USER 999
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 # Set env vars and display results.
-if [[ ${VCAP_SERVICES} ]]; then
+if [[ $VCAP_SERVICES ]]; then
   echo "Setting --redis-url exporter arg to \$VCAP_SERVICES.redis.credentials.uri value (private)."
-  RQ_REDIS_URL_ARG="--redis-url $(echo ${VCAP_SERVICES} | jq .redis[].credentials.uri -r)"
+  RQ_REDIS_URL_ARG="--redis-url $(echo $VCAP_SERVICES | jq .redis[].credentials.uri -r)"
 else
   echo "\$VCAP_SERVICES env var not set. \$RQ_REDIS_URL (if set) will be used by the exporter."
-  if [[ -z ${RQ_REDIS_URL} ]]; then
+  if [[ -z $RQ_REDIS_URL ]]; then
     echo "Note that \$RQ_REDIS_URL is not set. Exporter may fail unless redis is local or \$RQ_EXPORTER_HOST is set instead. See https://github.com/mdawar/rq-exporter/blob/master/README.md"
   fi
 fi
 
-if [[ ${PORT} ]]; then
-  echo "Setting --port exporter arg to \$PORT env var value (which is ${PORT})."
-  RQ_EXPORTER_PORT_ARG="--port ${PORT}"
+if [[ $PORT ]]; then
+  echo "Setting --port exporter arg to \$PORT env var value (which is $PORT)."
+  RQ_EXPORTER_PORT_ARG="--port $PORT"
 else
   echo "\$PORT env var not set so unless\$RQ_EXPORTER_PORT is otherwise set, the exporter will be served on port 9726."
 fi
 
 # Run the exporter
 echo "Starting rq_exporter..."
-python -m rq_exporter ${RQ_REDIS_URL_ARG} ${RQ_EXPORTER_PORT_ARG}
+python -m rq_exporter $RQ_REDIS_URL_ARG $RQ_EXPORTER_PORT_ARG

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 # Set env vars and display results.
 if [[ ${VCAP_SERVICES} ]]; then
   echo "Setting \$RQ_REDIS_URL to \$VCAP_SERVICES.redis.credentials.uri value (private)."
-  export RQ_REDIS_URL=$(echo ${VCAP_SERVICES} | jq .redis[].credentials.uri -r)
+  RQ_REDIS_URL_ARG="--redis-url $(echo ${VCAP_SERVICES} | jq .redis[].credentials.uri -r)"
 else
   echo "\$VCAP_SERVICES env var not set. \$RQ_REDIS_URL (if set) will be used by the exporter."
   if [[ -z ${RQ_REDIS_URL} ]]; then
@@ -13,11 +13,11 @@ fi
 
 if [[ ${PORT} ]]; then
   echo "Setting \$RQ_EXPORTER_PORT to \$PORT env var value (which is ${PORT})."
-  export RQ_EXPORTER_PORT=$PORT
+  RQ_EXPORTER_PORT_ARG="--port ${PORT}"
 else
   echo "\$PORT env var not set so unless\$RQ_EXPORTER_PORT is otherwise set, the exporter will expect 9726."
 fi
 
 # Run the exporter
 echo "Starting rq_exporter..."
-python -m rq_exporter
+python -m rq_exporter ${RQ_REDIS_URL_ARG} ${RQ_EXPORTER_PORT_ARG}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 export RQ_REDIS_URL=$(echo $VCAP_SERVICES | jq .redis[].credentials.uri -r)
 export RQ_EXPORTER_PORT=$PORT
 python -m rq_exporter

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set env vars and display results.
-if [[ $VCAP_SERVICES ]]; then
+if ! [[ -z $VCAP_SERVICES ]]; then
   echo "Setting --redis-url exporter arg to \$VCAP_SERVICES.redis.credentials.uri value (private)."
   RQ_REDIS_URL_ARG="--redis-url $(echo $VCAP_SERVICES | jq .redis[].credentials.uri -r)"
 else
@@ -11,7 +11,7 @@ else
   fi
 fi
 
-if [[ $PORT ]]; then
+if ! [[ -z $PORT ]]; then
   echo "Setting --port exporter arg to \$PORT env var value (which is $PORT)."
   RQ_EXPORTER_PORT_ARG="--port $PORT"
 else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Set env vars and display results.
 if [[ ${VCAP_SERVICES} ]]; then
-  echo "Setting \$RQ_REDIS_URL to \$VCAP_SERVICES.redis.credentials.uri value (private)."
+  echo "Setting --redis-url exporter arg to \$VCAP_SERVICES.redis.credentials.uri value (private)."
   RQ_REDIS_URL_ARG="--redis-url $(echo ${VCAP_SERVICES} | jq .redis[].credentials.uri -r)"
 else
   echo "\$VCAP_SERVICES env var not set. \$RQ_REDIS_URL (if set) will be used by the exporter."
@@ -12,10 +12,10 @@ else
 fi
 
 if [[ ${PORT} ]]; then
-  echo "Setting \$RQ_EXPORTER_PORT to \$PORT env var value (which is ${PORT})."
+  echo "Setting --port exporter arg to \$PORT env var value (which is ${PORT})."
   RQ_EXPORTER_PORT_ARG="--port ${PORT}"
 else
-  echo "\$PORT env var not set so unless\$RQ_EXPORTER_PORT is otherwise set, the exporter will expect 9726."
+  echo "\$PORT env var not set so unless\$RQ_EXPORTER_PORT is otherwise set, the exporter will be served on port 9726."
 fi
 
 # Run the exporter

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export RQ_REDIS_URL=$(echo $VCAP_SERVICES | jq .redis[].credentials.uri -r)
+export RQ_EXPORTER_PORT=$PORT
+python -m rq_exporter

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
-export RQ_REDIS_URL=$(echo $VCAP_SERVICES | jq .redis[].credentials.uri -r)
-export RQ_EXPORTER_PORT=$PORT
+
+# Set env vars and display results.
+if [[ ${VCAP_SERVICES} ]]; then
+  echo "Setting \$RQ_REDIS_URL to \$VCAP_SERVICES.redis.credentials.uri value (private)."
+  export RQ_REDIS_URL=$(echo ${VCAP_SERVICES} | jq .redis[].credentials.uri -r)
+else
+  echo "\$VCAP_SERVICES env var not set. \$RQ_REDIS_URL (if set) will be used by the exporter."
+  if [[ -z ${RQ_REDIS_URL} ]]; then
+    echo "Note that \$RQ_REDIS_URL is not set. Exporter may fail unless redis is local or \$RQ_EXPORTER_HOST is set instead. See https://github.com/mdawar/rq-exporter/blob/master/README.md"
+  fi
+fi
+
+if [[ ${PORT} ]]; then
+  echo "Setting \$RQ_EXPORTER_PORT to \$PORT env var value (which is ${PORT})."
+  export RQ_EXPORTER_PORT=$PORT
+else
+  echo "\$PORT env var not set so unless\$RQ_EXPORTER_PORT is otherwise set, the exporter will expect 9726."
+fi
+
+# Run the exporter
+echo "Starting rq_exporter..."
 python -m rq_exporter

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,4 +20,5 @@ fi
 
 # Run the exporter
 echo "Starting rq_exporter..."
+echo "python -m rq_exporter ${RQ_REDIS_URL_ARG:0:22} $RQ_EXPORTER_PORT_ARG"
 python -m rq_exporter $RQ_REDIS_URL_ARG $RQ_EXPORTER_PORT_ARG

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
   - docker:
-      image: mdawar/rq-exporter:latest
+      image: gcr.io/sre-docker-registry/github.com/uktrade/prom-rq-exporter:latest
     health-check-type: port 


### PR DESCRIPTION
Applies the following changes:
- Custom Dockerfile to create an image with `jq` added and a custom entry-point script.
- Custom entry-point script to set exporter args based on `VCAP_SERVICES` and `PORT` env vars.
- Updated manifest to use PasS-specific custom image in GCR.